### PR TITLE
Reading the same environment flag that the docker agent client reads …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL gocd.version="17.11.0" \
   description="GoCD server based on alpine linux" \
   maintainer="GoCD <go-cd-dev@googlegroups.com>" \
   gocd.full.version="17.11.0-5520" \
-  gocd.git.sha="9f6909e2f64b07d2dce5cecd4ea5b92b8e19d6b1"
+  gocd.git.sha="447f05a43f568ce04fbaade785129def5c1cbcf1b78093afc65a1532d23729c4"
 
 # the ports that go server runs on
 EXPOSE 8153 8154
@@ -47,6 +47,7 @@ RUN \
   mv go-server-17.11.0 /go-server
 
 COPY logback-include.xml /go-server/config/logback-include.xml
+COPY template-cruise-config.xml /go-server/config/template-cruise-config.xml
 
 ADD docker-entrypoint.sh /
 

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -47,6 +47,7 @@ RUN \
   mv go-server-<%= gocd_version %> /go-server
 
 COPY logback-include.xml /go-server/config/logback-include.xml
+COPY template-cruise-config.xml /go-server/config/template-cruise-config.xml
 
 ADD docker-entrypoint.sh /
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -70,11 +70,12 @@ if [ "$1" = '/go-server/server.sh' ]; then
 
     # Ensure that there is a config file.
     if [ ! -f "${SERVER_WORK_DIR}/config/cruise-config.xml" ]; then
-      cp /go-server/config/template-cruise-config.xml "${SERVER_WORK_DIR}/config/cruise-config.xml"
+      try cp /go-server/config/template-cruise-config.xml "${SERVER_WORK_DIR}/config/cruise-config.xml"
     fi
 
     # Replace autoregisterkey.
     sed -i "s/AUTO_REGISTER_KEY/${AGENT_AUTO_REGISTER_KEY}/" "${SERVER_WORK_DIR}/config/cruise-config.xml"
+    try chown go:go "${SERVER_WORK_DIR}/config/cruise-config.xml"
 
     try exec /sbin/tini -- su-exec go "$0" "$@"
   fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -68,6 +68,14 @@ if [ "$1" = '/go-server/server.sh' ]; then
       try chown go:go "${VOLUME_DIR}/config/logback-include.xml"
     fi
 
+    # Ensure that there is a config file.
+    if [ ! -f "${SERVER_WORK_DIR}/config/cruise-config.xml" ]; then
+      cp /go-server/config/template-cruise-config.xml "${SERVER_WORK_DIR}/config/cruise-config.xml"
+    fi
+
+    # Replace autoregisterkey.
+    sed -i "s/AUTO_REGISTER_KEY/${AGENT_AUTO_REGISTER_KEY}/" "${SERVER_WORK_DIR}/config/cruise-config.xml"
+
     try exec /sbin/tini -- su-exec go "$0" "$@"
   fi
 fi

--- a/template-cruise-config.xml
+++ b/template-cruise-config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="97">
+  <server agentAutoRegisterKey="AUTO_REGISTER_KEY"/>
+</cruise>


### PR DESCRIPTION
…for auto registering the clients (from https://docs.gocd.org/current/advanced_usage/agent_auto_register.html), so that you can stick both the server and the agents in one shared docker-compose.yml and share environment keys and iterate on server/agents from scratch.